### PR TITLE
Updated client running instructions

### DIFF
--- a/angular-7-springboot-client/README.md
+++ b/angular-7-springboot-client/README.md
@@ -4,7 +4,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `npm start` or `ng serve --proxy-config proxy.conf.json` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 


### PR DESCRIPTION
The client should be run with either `npm start` or `ng serve --proxy-config proxy.conf.json` commands to enable proxy to 8080 port